### PR TITLE
Move definitions of IOFLAG and IORESULT before pass

### DIFF
--- a/compileline.c
+++ b/compileline.c
@@ -60,7 +60,7 @@ int compileLine(char* line) {
     else if (strcasecmp(token,"intr") == 0) line=cintr(line+4);
     else if (strcasecmp(token,"ioff") == 0) line=cioff(line+4);
     else if (strcasecmp(token,"ion") == 0) line=cion(line+3);
-    else if (strcasecmp(token,"let ") == 0) line=clet(line+4);
+    else if (strcasecmp(token,"let") == 0) line=clet(line+3);
     else if (strcasecmp(token,"rem") == 0) line=crem(line+3);
     else if (strcasecmp(token,"return") == 0) line=creturn(line+6);
     else if (strcasecmp(token,"poke") == 0) line=cpoke(line+4);
@@ -108,4 +108,3 @@ int compileLine(char* line) {
   if (passNumber == 2 && showCompiler) printf("\n");
   return 0;
   }
-

--- a/main.c
+++ b/main.c
@@ -224,6 +224,11 @@ int main(int argc, char** argv, char** envp) {
   codeGenerated = 0;
   highest = 0;
   prepass(sourceFile);
+  //grw - moved variable defs before pass 1
+  if (getDefine("FILES")) {
+    getVariable("IORESULT");
+    getVariable("IOFLAG");
+    }
   if (showOptions) {
     printf("Options in effect:\n");
     if (use32Bits) printf("  32-bits\n");
@@ -267,10 +272,6 @@ int main(int argc, char** argv, char** envp) {
     getVariable("STMP7_$");
     getVariable("STMP8_$");
     getVariable("STMP9_$");
-    }
-  if (getDefine("FILES")) {
-    getVariable("IORESULT");
-    getVariable("IOFLAG");
     }
   outCount = 0;
   outFile = open(outName,O_CREAT|O_TRUNC|O_WRONLY|O_BINARY,0666);
@@ -455,4 +456,3 @@ int main(int argc, char** argv, char** envp) {
     }
   if (createLst) fclose(lstFile);
   }
-


### PR DESCRIPTION
If the BASIC code does not specifically declare IOFLAG and IORESULT variables, an assembly error results in the compiled code. The fix is to move the getVariable() calls in main.c before the first call to pass so that these variables are implicitly declared.  This allows BASIC code to compile without explicitly defining these variables.