### PR TITLE
Update ioresults to set IOFLAG upper byte to zero when 32 bits

### DIFF
--- a/library.asm
+++ b/library.asm
@@ -6800,6 +6800,12 @@ ioresults:  plo    re              ; save return code
             ldi    v_ioflag.0
             plo    rf
             ldi    0               ; clear msb of ioflag
+#ifdef use32bits
+            str    rf              ; clear high word if 32 bits
+            inc    rf
+            str    rf
+            inc    rf
+#endif
             str    rf
             inc    rf
             shlc                   ; set D to DF
@@ -6808,4 +6814,3 @@ ioresults:  plo    re              ; save return code
 
 
 #endif
-


### PR DESCRIPTION
Copied the same block to set the upper byte of IORESULT into the code logic to set the upper byte of IOFLAG to zero when using 32-bits.