### PR TITLE
The function localtime_r is not available in Windows.  Use localtime_s instead.

### DIFF
--- a/header.h
+++ b/header.h
@@ -10,8 +10,10 @@
 #include <io.h>
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#define localtime_r(X,Y) (localtime_s(Y,X))
 #else
 #include <unistd.h>
+#include <sys/time.h>
 #define O_BINARY 0
 #endif
 
@@ -298,4 +300,3 @@ extern int  getDefine(char* define);
 extern void writeOutput();
 
 #endif
-

--- a/library.c
+++ b/library.c
@@ -22,9 +22,9 @@ void library() {
   struct tm tv;
  
   time_t epochSeconds;
-  epochSeconds = time(NULL);  
-  localtime_r(&(epochSeconds), &(tv));     
-  
+  epochSeconds = time(NULL);
+  localtime_r(&(epochSeconds), &(tv));
+
   ctmp = showCompiler;
   showCompiler = 0;
   Asm("scall:      equ  r4");

--- a/library.c
+++ b/library.c
@@ -10,7 +10,6 @@
 
 #include "header.h"
 #include "library.h"
-#include <sys/time.h>
 #include <time.h>
 
 // R7 - data stack
@@ -23,9 +22,9 @@ void library() {
   struct tm tv;
  
   time_t epochSeconds;
-  epochSeconds = time(NULL);
-  localtime_r(&(epochSeconds), &(tv));
-
+  epochSeconds = time(NULL);  
+  localtime_r(&(epochSeconds), &(tv));     
+  
   ctmp = showCompiler;
   showCompiler = 0;
   Asm("scall:      equ  r4");
@@ -226,4 +225,3 @@ void library() {
   showCompiler = ctmp;
   if (passNumber == 1) runtime = address;
   }
-

--- a/processoption.c
+++ b/processoption.c
@@ -110,6 +110,15 @@ void processOption(char* option) {
       lblF_msg = 0xff09;
       lblF_setbd = 0xff2d;
       }
+    if (strcmp(option,"-term=elfos") == 0) {
+      useSelfTerm = 0;
+      lblF_inmsg = 0x034b;
+      lblF_type = 0x0330;
+      lblF_read = 0x0309;
+      lblF_input = 0x0339;
+      lblF_msg = 0x0333;
+      lblF_setbd = 0x0360;
+      }      
     if (strcmp(option,"-term=self") == 0) {
       useSelfTerm = 0xff;
       lblF_inmsg = 0x0000;
@@ -214,4 +223,3 @@ void processOption(char* option) {
     if (strncmp(option,"-heap=",6) == 0) heap=getHex(option+6);
     if (strncmp(option,"-keybuf=",8) == 0) iBufferSize=getHex(option+8);
   }
-


### PR DESCRIPTION
Created a macro definition in header.h for localtime_r() to call localtime_s() under Windows and moved the include <sys/time> statement from library.c into the header.h file with the other Non-Windows code. 

I compiled the code under Windows and under Linux.  I also compiled the sample.bas program under both OS versions of sbc and verified the header information is correct and that both programs run correctly under the Elf/OS.
