### PR TITLE
Minor updates for sys/time and to add missing dependency to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ crename.o:       header.h crename.c
 crestore.o:      header.h crestore.c
 creturn.o:       header.h creturn.c
 crmdir.o:        header.h crmdir.c
+csexpr.o:        header.h csexpr.c
 findline.o:      header.h findline.c
 findvariable.o:  header.h findvariable.c
 gethex.o:        header.h gethex.c

--- a/header.h
+++ b/header.h
@@ -10,8 +10,10 @@
 #include <io.h>
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#define localtime_r(X,Y) (localtime_s(Y,X))
 #else
 #include <unistd.h>
+#include <sys/time.h>
 #define O_BINARY 0
 #endif
 
@@ -307,4 +309,3 @@ extern void writeOutput();
 extern void AddExternal(char* proc, char* name);
 
 #endif
-

--- a/library.c
+++ b/library.c
@@ -9,7 +9,6 @@
 */
 
 #include "header.h"
-#include <sys/time.h>
 #include <time.h>
 
 // R7 - data stack
@@ -206,4 +205,3 @@ void library() {
     }
   if (passNumber == 1) runtime = address;
   }
-


### PR DESCRIPTION
Updated library.c and header.h to move the include sys/time to Windows section of header file.  (This is the same change that was made in the main branch so the code can be built for Windows as well as Linux)

Updated Makefile to add missing dependency for csexpr.o. 